### PR TITLE
#164209369 Users can edit a vendor

### DIFF
--- a/tests/mocks/vendor_mock_data.py
+++ b/tests/mocks/vendor_mock_data.py
@@ -8,3 +8,13 @@ NEW_VENDOR = {
     "email": "new_vendor@example.com",
     "phone": "07068662986"
 }
+
+NEW_VENDOR_II = {
+    "name": "Business_edited",
+    "location": "Unknown Location",
+    "description": "New description",
+    "logo_url": "https://place-hold.it/300x500/fff",
+    "email": "new_vendor_edited@example.com",
+    "phone": "07068662986"
+}
+

--- a/tests/test_vendor/test_vendor_edit_endpoint.py
+++ b/tests/test_vendor/test_vendor_edit_endpoint.py
@@ -1,0 +1,95 @@
+"""Test for editing a vendor endpoint"""
+
+import pytest
+from django.urls import reverse
+
+from utils.messages import MESSAGES
+
+from tests.mocks.user_mock_data import NEW_USER, USER
+from tests.mocks.vendor_mock_data import NEW_VENDOR_II
+
+
+@pytest.mark.django_db
+class TestEditAVendorEndpoint:
+    """Test for getting a single vendor"""
+
+    def authenticate_user(self, authenticate_user, user):
+        """Authenticates users"""
+
+        token = authenticate_user(user)
+        return {
+            'HTTP_AUTHORIZATION': f'Bearer {token}'
+        }
+
+    def test_edit_a_vendor_succeeds(self, client, new_vendors,
+                                    authenticate_user):
+        """Test get a new vendor endpoint"""
+
+        auth_header = self.authenticate_user(authenticate_user, NEW_USER)
+        vendor = new_vendors
+        vendor_url = reverse('vendor:vendor-detail', args=[vendor[0].id])
+        response = client.patch(vendor_url,
+                                content_type='application/json',
+                                data=NEW_VENDOR_II, **auth_header)
+        resp = response.data
+        data = resp['data']
+
+        assert response.status_code == 200
+        assert resp['status'] == 'success'
+        assert resp['message'] == MESSAGES['UPDATED'].format('Vendor')
+        assert data['name'] == NEW_VENDOR_II['name']
+        assert data['location'] == NEW_VENDOR_II['location']
+        assert data['email'] == NEW_VENDOR_II['email']
+
+    def test_edit_a_vendor_created_by_another_user_fails(self, client,
+                                                         create_user,
+                                                         new_vendors,
+                                                         authenticate_user):
+        """Test get a new vendor endpoint"""
+
+        create_user(USER)
+        auth_header = self.authenticate_user(authenticate_user, USER)
+        vendor = new_vendors
+        vendor_url = reverse('vendor:vendor-detail', args=[vendor[2].id])
+        response = client.patch(vendor_url,
+                                content_type='application/json',
+                                data=NEW_VENDOR_II, **auth_header)
+        resp = response.data
+        assert response.status_code == 403
+        assert resp['status'] == 'error'
+        assert resp == MESSAGES['NO_PERMISSION']
+
+    def test_edit_a_non_existent_vendor_fails(self, client,
+                                              new_vendors,
+                                              authenticate_user):
+        """Test get a new vendor endpoint"""
+
+        auth_header = self.authenticate_user(authenticate_user, NEW_USER)
+        vendor_url = reverse('vendor:vendor-detail', args=['invalid'])
+        response = client.patch(vendor_url,
+                                content_type='application/json',
+                                data=NEW_VENDOR_II, **auth_header)
+        resp = response.data
+        assert response.status_code == 404
+        assert resp['status'] == 'error'
+        assert resp['message'] == MESSAGES['NOT_FOUND']
+
+    def test_edit_a_vendor_with_an_already_existing_values_fails(self,
+                                                                 client,
+                                                                 new_vendors,
+                                                                 authenticate_user):
+        """Test get a new vendor endpoint"""
+
+        auth_header = self.authenticate_user(authenticate_user, NEW_USER)
+        vendor = new_vendors
+        vendor_url = reverse('vendor:vendor-detail', args=[vendor[0].id])
+        response = client.patch(vendor_url,
+                                content_type='application/json',
+                                data={
+                                    "name": vendor[1].name
+                                }, **auth_header)
+        resp = response.data
+        assert response.status_code == 400
+        assert resp['status'] == 'error'
+        assert resp['errors']['name'][0] == MESSAGES['DUPLICATES'] \
+            .format('vendor', 'business name')

--- a/utils/custom_exception_handler.py
+++ b/utils/custom_exception_handler.py
@@ -13,16 +13,10 @@ def custom_exception_handler(exc, context):
     response = exception_handler(exc, context)
 
     # Now add the HTTP status code to the response.
-    if response.status_code == status.HTTP_404_NOT_FOUND:
+    if response and response.status_code == status.HTTP_404_NOT_FOUND:
         response.data = {
             'status': 'error',
             'message': MESSAGES['NOT_FOUND']
-        }
-
-    if response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR:
-        response.data = {
-            'status': 'error',
-            'message': MESSAGES['ERROR']
         }
 
     return response

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -7,6 +7,8 @@ MESSAGES = {
     },
     'FETCHED':
         '{} successfully fetched.',
+    'UPDATED':
+        '{} successfully updated.',
     'DUPLICATES':
         '{} with this {} already exists.',
     'CREATED':

--- a/utils/permissions.py
+++ b/utils/permissions.py
@@ -17,6 +17,14 @@ class VerifiedBusinessAccountPermission(BasePermission):
         return bool(user.is_superuser or
                     (user.is_verified and user.account_type == 'BUSINESS'))
 
+    def has_object_permission(self, request, view, obj):
+        """Does the object has permission"""
+
+        is_owner = bool(obj.owner == request.user)
+        is_superuser = bool(request.user.is_superuser)
+
+        return bool(is_superuser or is_owner)
+
 
 class IsAuthenticated(BasePermission):
     """Allows access only to authenticated users."""


### PR DESCRIPTION
#### What does this PR do?
- Implements the vendor edit endpoint.

#### Description of Task to be completed?
As a verified and logged in business account owner, I should be able to make an update on a vendor by making a `PATCH` request to this route `/vendor/<vendor_id>`.

#### How should this be manually tested?
- Fetch the branch with `git fetch origin ft-edit-a-vendor-164209369`
- Checkout to the branch with `git checkout ft-edit-a-vendor-164209369`
- Activate the virtual environment and start the app with `pipenv shell && python manage.py runserver`
- Make a PATCH request to the route `/vendor/<vendor_id>`

`PATCH /vendor/<vendor_id>`
```
{
    "name": "",
    "location": "",
    "description": "",
    "owner": "<owner_id>",
    "logo_url": "",
    "email": "",
    "phone": ""
}
```

RESPONSE
`201 CREATED`

Response data should have the following structure
```
{
    "message" : "Vendor successfully updated",
    "status" : "success"
     "data": {
         "name": "",
        "location": "",
        "description": "",
        "owner": "<owner_id>",
        "logo_url": "",
        "email": "",
        "phone": ""
    }
}
```

**NOTE** 
Must be a verified account.
Business account users can only view and edit the vendors created by them.

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
- [#164209369](https://www.pivotaltracker.com/story/show/164209369)

#### Screenshots (if appropriate)
- N/A

#### Questions:
 - N/A