### PR TITLE
ft(vendor): Delete a vendor

### DIFF
--- a/tests/test_vendor/test_get_a_vendor_endpoint.py
+++ b/tests/test_vendor/test_get_a_vendor_endpoint.py
@@ -9,12 +9,15 @@ from utils.messages import MESSAGES
 class TestGetAVendorEndpoint:
     """Test for getting a single vendor"""
 
+    def vendor_url(self, vendor_id):
+        """to generate vendor url"""
+        return reverse('vendor:vendor-detail', args=[vendor_id])
+
     def test_get_a_vendor_succeeds(self, client, create_user, new_vendors):
         """Test get a new vendor endpoint"""
 
         vendor = new_vendors
-        vendor_url = reverse('vendor:vendor-detail', args=[vendor[0].id])
-        response = client.get(vendor_url)
+        response = client.get(self.vendor_url(vendor[0].id))
         resp = response.data
         data = resp['data']
 
@@ -29,8 +32,7 @@ class TestGetAVendorEndpoint:
     def test_get_a_vendor_fails(self, client, create_user, new_vendors):
         """Test get a new vendor endpoint"""
 
-        vendor_url = reverse('vendor:vendor-detail', args=['invalid'])
-        response = client.get(vendor_url)
+        response = client.get(self.vendor_url('invalid'))
         resp = response.data
         assert response.status_code == 404
         assert resp['status'] == 'error'

--- a/tests/test_vendor/test_get_all_vendor_endpoint.py
+++ b/tests/test_vendor/test_get_all_vendor_endpoint.py
@@ -70,3 +70,18 @@ class TestGetAllVendorEndpoint:
 
         assert response.status_code == 403
         assert resp == MESSAGES['NO_PERMISSION']
+
+    def test_get_all_vendors_after_soft_delete(self, client,
+                                               authenticate_user, new_vendors):
+        vendors = new_vendors
+        vendors[0].deleted = True
+        vendors[0].save()
+        auth_header = self.authenticate_user(authenticate_user, NEW_USER)
+        response = client.get(VENDOR_URL, **auth_header)
+        resp = response.data
+        data = resp['data']
+
+        assert response.status_code == 200
+        assert len(data) == 3
+        assert resp['meta']['count'] == 3
+        assert data[0]['name'] == vendors[-1].name

--- a/tests/test_vendor/test_vendor_delete_endpoints.py
+++ b/tests/test_vendor/test_vendor_delete_endpoints.py
@@ -1,0 +1,137 @@
+"""Module to test the delete endpoint"""
+
+import pytest
+from django.urls import reverse
+from utils.messages import MESSAGES
+from vendor.models import Vendor
+
+from tests.mocks.user_mock_data import NEW_USER
+
+
+@pytest.mark.django_db
+class TestDeleteEndpoint:
+    """Class representing the delete endpoint tests."""
+
+    def vendor_url(self, vendor_id, type):
+        """to generate vendor url"""
+        mapper = {
+            'soft': 'vendor:vendor-detail',
+            'hard': 'vendor:vendor-hard-delete',
+            'restore': 'vendor:vendor-restore'
+        }
+        return reverse(mapper[type], args=[vendor_id])
+
+    def authenticate_user(self, authenticate_user, user):
+        """Authenticates users"""
+
+        token = authenticate_user(user)
+        return {
+            'HTTP_AUTHORIZATION': f'Bearer {token}'
+        }
+
+    def test_deleting_a_vendor_succeeds(self, client, create_user,
+                                        authenticate_user, new_vendors):
+        """Test that deleting a vendor succeeds"""
+
+        vendor = new_vendors
+        auth_header = self.authenticate_user(authenticate_user, NEW_USER)
+        response = client.delete(self.vendor_url(vendor[0].id, 'soft'),
+                                 **auth_header)
+        updated_vendors = Vendor.objects.filter(id=vendor[0].id).first()
+        resp = response.data
+
+        assert response.status_code == 200
+        assert resp['status'] == 'success'
+        assert resp['message'] == MESSAGES['DELETED'].format('Vendor')
+        assert updated_vendors.deleted
+
+    def test_deleting_already_soft_deleted_vendor_fails(self, client,
+                                                        create_user,
+                                                        authenticate_user,
+                                                        new_vendors):
+        """Test that deleting a vendor succeeds"""
+
+        vendor = new_vendors
+        vendor[0].deleted = True
+        vendor[0].save()
+        auth_header = self.authenticate_user(authenticate_user, NEW_USER)
+        response = client.delete(self.vendor_url(vendor[0].id, 'soft'),
+                                 **auth_header)
+        resp = response.data
+
+        assert response.status_code == 404
+        assert resp['status'] == 'error'
+        assert resp['message'] == MESSAGES['NOT_FOUND']
+
+    def test_restore_a_nonexistent_vendor_fails(self, client, create_user,
+                                                authenticate_user,
+                                                new_vendors):
+        """Test that deleting a vendor succeeds"""
+
+        auth_header = self.authenticate_user(authenticate_user, NEW_USER)
+        response = client.get(self.vendor_url('invalid', 'restore'),
+                              **auth_header)
+        resp = response.data
+
+        assert response.status_code == 404
+        assert resp['status'] == 'error'
+        assert resp['message'] == MESSAGES['NOT_FOUND']
+
+    def test_restoring_a_deleted_vendor_succeeds(self, client, create_user,
+                                                 authenticate_user,
+                                                 new_vendors):
+        """Test that deleting a vendor succeeds"""
+
+        vendor = new_vendors
+        auth_header = self.authenticate_user(authenticate_user, NEW_USER)
+        response = client.get(self.vendor_url(vendor[0].id, 'restore'),
+                              **auth_header)
+        resp = response.data
+
+        assert response.status_code == 200
+        assert resp['status'] == 'success'
+        assert resp['message'] == MESSAGES['RESTORE'].format('Vendor',
+                                                             vendor[0].name)
+
+    def test_soft_deleting_a_nonexistent_vendor_fails(self, client, create_user,
+                                                      authenticate_user,
+                                                      new_vendors):
+        """Test that deleting a vendor succeeds"""
+
+        auth_header = self.authenticate_user(authenticate_user, NEW_USER)
+        response = client.delete(self.vendor_url('invalid', 'soft'),
+                                 **auth_header)
+        resp = response.data
+
+        assert response.status_code == 404
+        assert resp['status'] == 'error'
+        assert resp['message'] == MESSAGES['NOT_FOUND']
+
+    def test_hard_deleting_a_vendor_succeeds(self, client, create_user,
+                                             authenticate_user,
+                                             new_vendors):
+        """Test that deleting a vendor succeeds"""
+
+        vendor = new_vendors
+        auth_header = self.authenticate_user(authenticate_user, NEW_USER)
+        response = client.delete(self.vendor_url(vendor[0].id, 'hard'),
+                                 **auth_header)
+        resp = response.data
+
+        assert response.status_code == 200
+        assert resp['status'] == 'success'
+        assert resp['message'] == MESSAGES['P_DELETED'].format('Vendor')
+
+    def test_hard_deleting_a_nonexistent_vendor_fails(self, client, create_user,
+                                                      authenticate_user,
+                                                      new_vendors):
+        """Test that deleting a vendor succeeds"""
+
+        auth_header = self.authenticate_user(authenticate_user, NEW_USER)
+        response = client.delete(self.vendor_url('invalid', 'hard'),
+                                 **auth_header)
+        resp = response.data
+
+        assert response.status_code == 404
+        assert resp['status'] == 'error'
+        assert resp['message'] == MESSAGES['NOT_FOUND']

--- a/utils/messages.py
+++ b/utils/messages.py
@@ -7,6 +7,12 @@ MESSAGES = {
     },
     'FETCHED':
         '{} successfully fetched.',
+    'DELETED':
+        '{} successfully deleted.',
+    'P_DELETED':
+        '{} permanently deleted.',
+    'RESTORE':
+        '{} with name: "{}" successfully restored.',
     'UPDATED':
         '{} successfully updated.',
     'DUPLICATES':


### PR DESCRIPTION
#### What does this PR do?
- Implements the deleting and restoring soft-deleted vendor endpoints.

#### Description of Task to be completed?
As a verified and logged in business account owner, I should be able to soft delete a vendor by making a `DELETE` request to this route `/vendor/<vendor_id>`,  be able to permanently delete a vendor with by making a `DELETE` request to this route `vendor/<vendor_id>/delete`, and also restore a soft-deleted  vendor by making a `GET` request to this route `vendor/<vendor_id>/restore`

#### How should this be manually tested?
- Fetch the branch with `git fetch origin ft-vendor-delete-164210010`
- Checkout to the branch with `git checkout ft-vendor-delete-164210010`
- Activate the virtual environment and start the app with `pipenv shell && python manage.py runserver`
- Make a DELETE request to the route `/vendor/<vendor_id>`
- Make a DELETE request to the route `/vendor/<vendor_id>/delete`
- Make a GET request to the route `/vendor/<vendor_id>/restore`

`DELETE /vendor/<vendor_id>`
RESPONSE
`200 OK`

Response data should have the following structure
```
{
    "status": "success",
    "message": "Vendor successfully deleted."
}
```


`GET /vendor/<vendor_id>/restore`
RESPONSE
`200 OK`

Response data should have the following structure
```
{
    "status": "success",
    "message": "Vendor with name: "<vendor_name>" successfully restored.",
    "data": {
        "id": "<vendor_id>",
        "name": "<vendor_name>",
        "location": "<vendor_location>",
        "description": "<vendor_description>",
        "owner": "<owner_id>",
        "logo_url": "https://placehold.it/500X500",
        "email": "<vendor_email>",
        "phone": "<vendor_phone>"
    }
}
```

`DELETE /vendor/<vendor_id>/delete`

RESPONSE
`200 OK`

Response data should have the following structure
```
{
    "status": "success",
    "message": "Vendor permanently deleted."
}
```

**NOTE** 
Must be a verified account.
Business account users can only view the vendors created by them.

#### Any background context you want to provide?
- N/A

#### What are the relevant pivotal tracker stories?
- [#164210010](https://www.pivotaltracker.com/story/show/164210010)

#### Screenshots (if appropriate)
- N/A

#### Questions:
 - N/A